### PR TITLE
feat: support for year-based URL param on Team page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5370,9 +5370,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001660",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-			"integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+			"version": "1.0.30001723",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+			"integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5386,7 +5386,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/ccount": {
 			"version": "2.0.1",

--- a/src/components/Team/TeamPage.jsx
+++ b/src/components/Team/TeamPage.jsx
@@ -1,169 +1,82 @@
 import React, { useState, useEffect } from "react";
-import "../../global.css";
-import shape from "../../assets/patterns/ssshape.svg";
-import { sanityClient } from "sanity:client";
-import { useStore } from "@nanostores/react";
-import { locale, t } from "../../i18n";
-import imageUrlBuilder from "@sanity/image-url";
 import AOS from "aos";
 import "aos/dist/aos.css";
+import { useStore } from "@nanostores/react";
+import { FontAwesomeIcon as Icon } from "@fortawesome/react-fontawesome";
 import { faLinkedin, faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faGlobe } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon as Icon } from "@fortawesome/react-fontawesome";
-import Construction from "../Construction/Construction";
+import imageUrlBuilder from "@sanity/image-url";
 
-export default function TeamPage({ teams }) {
-	const [selectedYear, setSelectedYear] = useState(teams?.sort((a, b) => b.year - a.year)?.[0]?.year?.toString());
-	const $locale = useStore(locale);
-	const builder = imageUrlBuilder(sanityClient);
-	const t_teamNames = t("team.teams");
-	const t_positions = t("team.positions");
-	let suf = `year_${selectedYear}`;
-	const [subTeams, setSubTeams] = useState({});
+import "../../global.css";
+import shape from "../../assets/patterns/ssshape.svg";
 
-	function urlFor(source) {
-		return builder.image(source);
-	}
+import { sanityClient } from "sanity:client";
+import { locale, t } from "../../i18n";
 
-	useEffect(() => {
-		AOS.init({ once: false, duration: 700 });
-	}, []);
+const executiveRoles = ["President", "ExecutiveVP", "VPOperations", "CoDirector", "DirectorAtLarge", "Secretary"];
 
-	const executiveRoles = ["President", "ExecutiveVP", "VPOperations", "CoDirector", "DirectorAtLarge", "Secretary"];
+const redCardRoles = [
+	"President",
+	"VPOperations",
+	"ExecutiveVP",
+	"Director",
+	"VP",
+	"Co-VP",
+	"Manager",
+	"CoDirector",
+	"DirectorAtLarge",
+	"Secretary",
+];
 
-	useEffect(() => {
-		const newSubTeams = {};
-		const teamObj = teams?.find(currTeam => currTeam?.year?.toString() === selectedYear);
-		teamObj?.members?.forEach(member => {
-			const assignmentsForYear = member.assignments?.[suf] || [];
-			const hasExecutive = assignmentsForYear.some(
-				a => executiveRoles.includes(a.position) || a.teamName === "Executive",
-			);
-			if (hasExecutive) {
-				// For board of directors, determine the effective assignment:
-				// Use the assignment whose position is in executiveRoles
-				let effectiveExec = assignmentsForYear.find(a => executiveRoles.includes(a.position));
-				if (!effectiveExec) {
-					const alternative = assignmentsForYear.find(
-						a => !executiveRoles.includes(a.position) && a.position,
-					);
-					effectiveExec = alternative || assignmentsForYear.find(a => executiveRoles.includes(a.position));
-				}
-				if (!newSubTeams["Executive"]) {
-					newSubTeams["Executive"] = [];
-				}
-				// Force grouping under 'Executive' for board of directors
-				newSubTeams["Executive"].push({ ...member, assignment: effectiveExec });
-			}
-			// For assignments that are not part of the Executive grouping, add them normally
-			assignmentsForYear.forEach(assignment => {
-				if (assignment.teamName !== "Executive") {
-					const group = assignment.teamName || "Member";
-					if (!newSubTeams[group]) {
-						newSubTeams[group] = [];
-					}
-					newSubTeams[group].push({ ...member, assignment });
-				}
-			});
-		});
+const rankOrder = [
+	"President",
+	"VPOperations",
+	"ExecutiveVP",
+	"DirectorAtLarge",
+	"Secretary",
+	"Director",
+	"CoDirector",
+	"Co-VP",
+	"VP",
+	"Manager",
+	"Coordinator",
+	"Advisor",
+];
 
-		Object.keys(newSubTeams).forEach(subTeam => {
-			newSubTeams[subTeam] = newSubTeams[subTeam].sort((a, b) => {
-				const rankOrder = [
-					"President",
-					"VPOperations",
-					"ExecutiveVP",
-					"DirectorAtLarge",
-					"Secretary",
-					"Director",
-					"CoDirector",
-					"Co-VP",
-					"VP",
-					"Manager",
-					"Coordinator",
-					"Advisor",
-				];
-				const rankA =
-					rankOrder.indexOf(a.assignment.position) !== -1
-						? rankOrder.indexOf(a.assignment.position)
-						: Infinity;
-				const rankB =
-					rankOrder.indexOf(b.assignment.position) !== -1
-						? rankOrder.indexOf(b.assignment.position)
-						: Infinity;
-				if (rankA !== rankB) return rankA - rankB;
-				return a.name.localeCompare(b.name);
-			});
-		});
+const contributors = ["Sacha Arseneault", "Erik Ang", "Daniel Thorp", "Surendar Pala Danasekaran"];
 
-		setSubTeams(newSubTeams);
-	}, [selectedYear, teams]);
+const normalize = str => str?.trim().toLowerCase() ?? "";
+const isExecutivePosition = pos => executiveRoles.map(normalize).includes(normalize(pos));
+const isExecutiveTeam = team => normalize(team) === "executive";
+const getKey = m => m._id ?? `${m.name}-${m.assignment?.position ?? ""}-${m.assignment?.teamName ?? ""}`;
 
-	const redCardRoles = [
-		"President",
-		"VPOperations",
-		"ExecutiveVP",
-		"Director",
-		"VP",
-		"Co-VP",
-		"Manager",
-		"CoDirector",
-		"DirectorAtLarge",
-		"Secretary",
-	];
+function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) {
+	const fallbackAsset = teams.find(t => t.year.toString() === selectedYear)?.fallbackPhoto?.asset;
+	const photoAsset = member?.photo?.[suf]?.asset ?? fallbackAsset;
+	const photoUrl = photoAsset ? urlFor(photoAsset).url() : "";
 
-	const memberCard = (member, i) => (
+	return (
 		<li
-			key={i}
 			className="basis-1/4 xl:basis-1/3 md:basis-1/2 p-4 md:p-1 min-h-[22rem] md:min-h-[14rem]"
 			data-aos="fade-up"
 		>
 			<div
 				className={`flex justify-between flex-col h-full text-center gap-2 md:gap-1 p-4 md:p-2 rounded-3xl overflow-hidden border border-theme-red transition-all ease-in-out duration-300 hover:-translate-y-2 hover:border-primary ${
-					redCardRoles.includes(member.assignment.position) ? "bg-blur-svg" : "bg-dark"
-				} ${(member.name === "Sacha Arseneault" || member.name === "Erik Ang") && "hover:animate-glow"}`}
+					redCardRoles.includes(member.assignment?.position) ? "bg-blur-svg" : "bg-dark"
+				} ${contributors.includes(member.name) ? "hover:animate-glow" : ""}`}
 			>
 				<img
-					src={
-						member?.photo?.[suf]
-							? urlFor(member?.photo?.[suf].asset).url()
-							: urlFor(
-									teams?.find(currTeam => currTeam?.year?.toString() === selectedYear)?.fallbackPhoto
-										?.asset,
-							  ).url()
-					}
+					src={photoUrl}
+					alt={member?.name || t("team.fallbackPhotoAlt")}
 					loading="lazy"
-					alt={member.name}
 					className="aspect-square object-cover rounded-[50%] shadow-small-glow"
 				/>
 				<h6 className="mt-2">{member.name}</h6>
-
-				{member.assignment && member.assignment.teamName && member.assignment.position ? (
-					member.assignment.teamName === "Executive" ? (
-						<h5>{t_positions[member.assignment.position]}</h5>
-					) : member.assignment.position === "VP" || member.assignment.position === "CoVP" ? (
-						<h5>{`${t_positions[member.assignment.position]} of ${
-							t_teamNames[member.assignment.teamName]
-						}`}</h5>
-					) : $locale === "en" ? (
-						<h5>{`${t_teamNames[member.assignment.teamName]} ${
-							t_positions[member.assignment.position]
-						}`}</h5>
-					) : (
-						<h5>{`${t_positions[member.assignment.position]} ${
-							t_teamNames[member.assignment.teamName]
-						}`}</h5>
-					)
-				) : member.assignment && member.assignment.position ? (
-					<h5>{t_positions[member.assignment.position]}</h5>
-				) : (
-					<h5>{t_positions?.member}</h5>
-				)}
-
-				<div className="w-full flex flex-row justify-center items-center gap-4 text-xl h-8">
-					{member?.linkedin && (
+				<h5>{getTitle(member)}</h5>
+				<div className="w-full flex justify-center gap-4 text-xl h-8">
+					{member.linkedin && (
 						<a
-							href={member?.linkedin}
+							href={member.linkedin}
 							target="_blank"
 							rel="noreferrer"
 							aria-label="LinkedIn"
@@ -172,23 +85,23 @@ export default function TeamPage({ teams }) {
 							<Icon icon={faLinkedin} />
 						</a>
 					)}
-					{member?.github && (
+					{member.github && (
 						<a
-							href={member?.github}
+							href={member.github}
 							target="_blank"
 							rel="noreferrer"
-							aria-label="LinkedIn"
+							aria-label="GitHub"
 							className="transition-all duration-300 text-white hover:opacity-100 opacity-80"
 						>
 							<Icon icon={faGithub} />
 						</a>
 					)}
-					{member?.website && (
+					{member.website && (
 						<a
-							href={member?.website}
+							href={member.website}
 							target="_blank"
 							rel="noreferrer"
-							aria-label="LinkedIn"
+							aria-label="Website"
 							className="transition-all duration-300 text-white hover:opacity-100 opacity-80"
 						>
 							<Icon icon={faGlobe} />
@@ -198,46 +111,154 @@ export default function TeamPage({ teams }) {
 			</div>
 		</li>
 	);
+}
+
+export default function TeamPage({ teams }) {
+	const $locale = useStore(locale);
+	const t_teamNames = t("team.teams");
+	const t_positions = t("team.positions");
+
+	const builder = imageUrlBuilder(sanityClient);
+	const urlFor = source => builder.image(source);
+
+	const defaultYear = teams[0]?.year.toString() ?? "";
+	const [selectedYear, setSelectedYear] = useState(() => {
+		if (typeof window !== "undefined") {
+			const param = new URLSearchParams(window.location.search).get("year");
+			const validYears = teams.map(t => t.year.toString());
+			return validYears.includes(param) ? param : defaultYear;
+		}
+		return defaultYear;
+	});
+
+	const suf = `year_${selectedYear}`;
+	const [subTeams, setSubTeams] = useState({});
+
+	// Sync year param in URL
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		if (selectedYear === defaultYear) {
+			params.delete("year");
+		} else {
+			params.set("year", selectedYear);
+		}
+		const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ""}`;
+		window.history.replaceState({}, "", newUrl);
+	}, [selectedYear, defaultYear]);
+
+	// Init AOS
+	useEffect(() => {
+		AOS.init({ once: false, duration: 700 });
+	}, []);
+
+	// Organize subTeams
+	useEffect(() => {
+		const teamObj = teams.find(t => t.year.toString() === selectedYear);
+		if (!teamObj) return setSubTeams({});
+
+		const newSubTeams = {};
+
+		for (const member of teamObj.members || []) {
+			const assignments = member.assignments?.[suf] ?? [];
+
+			const isExec = assignments.some(a => isExecutivePosition(a?.position) || isExecutiveTeam(a?.teamName));
+
+			if (isExec) {
+				const effectiveExec =
+					assignments.find(a => isExecutivePosition(a?.position)) ||
+					assignments.find(a => a?.position) ||
+					assignments[0];
+				if (effectiveExec) {
+					(newSubTeams["Executive"] ??= []).push({ ...member, assignment: effectiveExec });
+				}
+			}
+
+			for (const a of assignments) {
+				const teamName = a?.teamName?.trim();
+				if (teamName && !isExecutiveTeam(teamName)) {
+					const group = teamName || "Member";
+					(newSubTeams[group] ??= []).push({ ...member, assignment: a });
+				}
+			}
+		}
+
+		Object.entries(newSubTeams).forEach(([key, members]) => {
+			newSubTeams[key] = members.sort((a, b) => {
+				const rankA = rankOrder.indexOf(a.assignment?.position?.trim() ?? "");
+				const rankB = rankOrder.indexOf(b.assignment?.position?.trim() ?? "");
+				return (rankA === -1 ? Infinity : rankA) - (rankB === -1 ? Infinity : rankB);
+			});
+		});
+
+		setSubTeams(newSubTeams);
+	}, [selectedYear, teams]);
+
+	const getTitle = member => {
+		const a = member.assignment;
+		if (!a) return t_positions?.member;
+
+		const team = a.teamName?.trim();
+		const pos = a.position?.trim();
+		if (!pos) return t_positions?.member;
+
+		const teamLabel = t_teamNames?.[team] ?? team ?? "";
+		const positionLabel = t_positions?.[pos] ?? pos ?? "";
+
+		if (isExecutiveTeam(team)) return positionLabel;
+		if (["vp", "co-vp"].includes(normalize(pos))) return `${positionLabel} of ${teamLabel}`;
+
+		return $locale === "en" ? `${teamLabel} ${positionLabel}` : `${positionLabel} ${teamLabel}`;
+	};
 
 	return (
 		<div className="flex justify-center items-center w-full bg-background-dark relative overflow-hidden">
 			<div className="flex flex-col w-10/12 h-full justify-center items-center gap-20 py-36 text-left max-w-2xl z-[1] md:w-11/12">
 				<div className="flex flex-row justify-between items-center text-left w-full" data-aos="fade-up">
-					<h1 data-aos="fade-up">{t("team.title")}</h1>
+					<h1>{t("team.title")}</h1>
 					<select
 						className="w-auto h-10 py-2 px-4 rounded-lg bg-blur-svg cursor-pointer"
 						onChange={e => setSelectedYear(e.target.value)}
 						value={selectedYear}
+						aria-label={t("team.selectYear")}
 					>
-						{teams
-							?.sort((a, b) => b.year - a.year)
-							.map((team, i) => (
-								<option key={i} value={team.year.toString()}>
-									{team.year.toString()}
-								</option>
-							))}
+						{teams.map(team => (
+							<option key={team.year} value={String(team.year)}>
+								{team.year}
+							</option>
+						))}
 					</select>
 				</div>
+
 				<ul className="flex flex-wrap justify-evenly w-10/12 max-w-2xl gap-16">
-					{subTeams &&
-						Object.keys(subTeams)
-							.sort((a, b) => (a === "Executive" ? -1 : b === "Executive" ? 1 : a.localeCompare(b)))
-							.map((subTeam, i) => (
-								<li key={i} className="w-full">
-									<h2>
-										{subTeam === "Executive"
-											? t_teamNames?.[subTeam]
-											: $locale === "en"
-											? t_teamNames?.[subTeam]
-											: t_teamNames?.[subTeam]?.split(" ").slice(-1)[0]}
-									</h2>
-									<ul className="flex flex-wrap justify-start w-full mt-2">
-										{subTeams[subTeam].map((member, i) => memberCard(member, i))}
-									</ul>
-								</li>
-							))}
+					{Object.keys(subTeams)
+						.sort((a, b) => (a === "Executive" ? -1 : b === "Executive" ? 1 : a.localeCompare(b)))
+						.map(subTeam => (
+							<li key={subTeam} className="w-full">
+								<h2>
+									{subTeam === "Executive"
+										? t_teamNames[subTeam]
+										: $locale === "en"
+										? t_teamNames[subTeam]
+										: t_teamNames[subTeam]?.split(" ").slice(-1)[0]}
+								</h2>
+								<ul className="flex flex-wrap justify-start w-full mt-2">
+									{subTeams[subTeam].map(member => (
+										<TeamMemberCard
+											key={getKey(member)}
+											member={member}
+											suf={suf}
+											selectedYear={selectedYear}
+											teams={teams}
+											getTitle={getTitle}
+											urlFor={urlFor}
+										/>
+									))}
+								</ul>
+							</li>
+						))}
 				</ul>
 			</div>
+
 			<img
 				src={shape.src}
 				alt="shape"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -205,6 +205,8 @@ export default {
 			Sponsorship: "Sponsorship",
 		},
 		member: "Member",
+		selectYear: "Select team year",
+		fallbackPhotoAlt: "Team member photo",
 	},
 	events: {
 		title: "Events",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -208,6 +208,8 @@ export default {
 			Sponsorship: "de Partenariats",
 		},
 		member: "Membre",
+		selectYear: "Sélectionner l'année de l'équipe",
+		fallbackPhotoAlt: "Photo du membre de l'équipe",
 	},
 	events: {
 		title: "Événements",

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -1,17 +1,20 @@
 ---
 import TeamPage from "../components/Team/TeamPage";
 import Layout from "../layouts/Layout.astro";
+import { sanityClient } from "sanity:client";
+
 const title = "Capital Technology Network - Team";
 const pathName = "/team";
-import { sanityClient } from "sanity:client";
+
 const query = `*[_type == "newTeam"] {
   year,
   fallbackPhoto,
   members[]->
 }`;
-const teams = await sanityClient.fetch(query);
+type Team = { year: number; fallbackPhoto: any; members: any[] };
+const teams = (await sanityClient.fetch(query)).sort((a: Team, b: Team) => b.year - a.year);
 ---
 
 <Layout title={title} pathName={pathName}>
-	<TeamPage teams={teams} client:load />
+	<TeamPage client:load teams={teams} />
 </Layout>


### PR DESCRIPTION
This PR improves the Team page with two key enhancements:
- The selected team year is now reflected in the ?year= URL parameter, allowing users to share a specific year's team.
- Members are now grouped more consistently by team

These changes improve navigation, readability, and user experience without altering the visual layout.