### PR TITLE
fix: improve navigation accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Avoid Duplicating Nav ARIA Labels
+
+**Learning:** Found a common accessibility pitfall: a mobile hamburger menu button was using the same `aria-label` ("Navigation Bar") as its parent `<nav>` element. This creates confusion for screen reader users as they hear the exact same label for both the container and the control that toggles it. Another improvement was adding an aria-label to the language toggler ("EN"/"FR"), which without a label, just reads "E N" out of context.
+**Action:** When implementing mobile menus, always ensure the toggle button has a distinct, action-oriented label (e.g., "Toggle Navigation Menu") separate from the landmark label of the `<nav>` element itself. Always provide context to language togglers.

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -45,6 +45,7 @@ export default function Navigation(props) {
 					<button
 						className="flex h-full w-16 xs:w-12 items-center bg-transparent border-none p-4 xs:p-2 cursor-pointer font-bold transition-all duration-100 hover:text-shade-1 focus-visible:text-shade-1"
 						type="button"
+						aria-label={t("navbar.language_toggle")}
 						onClick={() => {
 							locale.set($locale === "en" ? "fr" : "en");
 						}}
@@ -64,7 +65,7 @@ export default function Navigation(props) {
 					<button
 						id="menu"
 						type="button"
-						aria-label={t("navbar.aria_label")}
+						aria-label={t("navbar.menu_aria_label")}
 						aria-expanded={sidebarOpen}
 						aria-controls="sidebar"
 						className="hidden h-full bg-transparent border-none cursor-pointer p-2 lg:block"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -45,6 +45,8 @@ export default {
 	navbar: {
 		links: { events: "Events", blog: "Blog", documents: "Documents", team: "Team" },
 		aria_label: "Navigation Bar",
+		menu_aria_label: "Toggle Navigation Menu",
+		language_toggle: "Toggle Language",
 	},
 	hero: {
 		title: "Capital Technology Network",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -45,6 +45,8 @@ export default {
 	navbar: {
 		links: { events: "Événements", blog: "Blogue", documents: "Documents", team: "Équipe" },
 		aria_label: "Barre de navigation",
+		menu_aria_label: "Basculer le menu de navigation",
+		language_toggle: "Basculer la langue",
 	},
 	hero: {
 		title: "Réseau technologique de la capitale",


### PR DESCRIPTION
💡 What: Added distinct ARIA labels to the language toggle and the mobile navigation menu button.
🎯 Why: Prevents duplicate landmark labels (e.g., both `<nav>` and its toggle button saying "Navigation Bar"), making it clear to screen reader users what each element does.
♿ Accessibility: Provides explicit context to icon-based buttons that lack visible text, improving standard compliance.

---
*PR created automatically by Jules for task [2175721298550418255](https://jules.google.com/task/2175721298550418255) started by @arcanistzed*