### PR TITLE
fix(a11y): expose toggle state to assistive technology

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Found a common accessibility pitfall: a mobile hamburger menu button was using the same `aria-label` ("Navigation Bar") as its parent `<nav>` element. This creates confusion for screen reader users as they hear the exact same label for both the container and the control that toggles it. Another improvement was adding an aria-label to the language toggler ("EN"/"FR"), which without a label, just reads "E N" out of context.
 **Action:** When implementing mobile menus, always ensure the toggle button has a distinct, action-oriented label (e.g., "Toggle Navigation Menu") separate from the landmark label of the `<nav>` element itself. Always provide context to language togglers.
+
+## 2024-08-18 - Communicating State on Custom Toggle Buttons
+
+**Learning:** Found several custom toggle buttons (e.g., calendar day selectors, event filters, gallery album selectors) that visually indicate their active/selected state using classes, but fail to communicate this state to screen readers.
+**Action:** When building custom toggle buttons that control UI state, always include `aria-pressed="true|false"` (for toggle buttons) or `aria-selected="true|false"` (for tab-like selectors) to ensure assistive technologies can announce the current state.

--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -139,6 +139,7 @@ export default function Calendar({ events }) {
 						>
 							<button
 								type="button"
+								aria-pressed={isEqual(day, selectedDay)}
 								onClick={() => {
 									setSelectedDay(day);
 									setShowUpcomingEvents(0);
@@ -191,6 +192,7 @@ export default function Calendar({ events }) {
 							<div className="flex flex-row justify-center items-center shadow-glow text-sm xs:text-xs">
 								<button
 									type="button"
+									aria-pressed={showUpcomingEvents === -1}
 									onClick={() => setShowUpcomingEvents(-1)}
 									className={`${getToggleClassName(-1)} border-r-[0.5px] rounded-l-md`}
 								>
@@ -198,6 +200,7 @@ export default function Calendar({ events }) {
 								</button>
 								<button
 									type="button"
+									aria-pressed={showUpcomingEvents === 0}
 									onClick={() => setShowUpcomingEvents(0)}
 									className={`${getToggleClassName(0)} border-l-[0.5px] border-r-[0.5px]`}
 								>
@@ -205,6 +208,7 @@ export default function Calendar({ events }) {
 								</button>
 								<button
 									type="button"
+									aria-pressed={showUpcomingEvents === 1}
 									onClick={() => setShowUpcomingEvents(1)}
 									className={`${getToggleClassName(1)} border-l-[0.5px] rounded-r-md`}
 								>

--- a/src/components/Gallery/Gallery.jsx
+++ b/src/components/Gallery/Gallery.jsx
@@ -131,6 +131,7 @@ export default function Gallery() {
 							<button
 								type="button"
 								key={album.tag}
+								aria-pressed={album.tag === activeFolder}
 								onClick={() => {
 									handleCardClick(album.tag);
 								}}


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` attributes to custom UI toggle buttons (calendar selectors, gallery selectors, and event filters).

🎯 **Why**: While these buttons visually communicated their active/selected states using varied styling and classes, screen readers and assistive tech had no programmatic way to know which options were currently pressed or selected.

♿ **Accessibility**: Improves WCAG compliance by making state changes perceivable to screen reader users via the `aria-pressed` attribute, allowing them to confidently navigate between custom selectable elements without relying on visual cues.

---
*PR created automatically by Jules for task [14141166760100621626](https://jules.google.com/task/14141166760100621626) started by @arcanistzed*