### PR TITLE
perf(i18n): hoist team page translations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 
 **Learning:** In this codebase, the translation function `t()` exported from `src/i18n.ts` is not a simple utility function but a React hook (`useT` under the hood) that subscribes to a nanostore.
 **Action:** Be extremely careful when using `t()` inside arrays of objects or data structures within a component's render body. Each call creates a separate subscription. Try to extract static data outside the component or `useMemo` these arrays, and pass localized strings directly instead of calling the hook multiple times if it causes performance issues, or better yet, avoid recreating large arrays that use `t()` on every render.
+
+## 2024-08-19 - i18n hook usage within large list items
+
+**Learning:** Building on the previous observation, calling the `t()` hook inside components that are rendered in large arrays (like `TeamMemberCard` rendered for every member) spawns a massive amount of nanostore subscriptions ($M \times N$ subscriptions for $M$ hook calls over $N$ items), which can measurably degrade performance during rendering and language switching.
+**Action:** Extract static translation strings into the parent component (e.g. `TeamPage`) where they are evaluated exactly once, and pass them down as a single `labels` prop object to child list items.

--- a/src/components/Team/TeamPage.jsx
+++ b/src/components/Team/TeamPage.jsx
@@ -58,7 +58,7 @@ const sortRank = rank => {
 	return rank;
 };
 
-function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) {
+function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor, labels }) {
 	const fallbackAsset = teams.find(t => t.year.toString() === selectedYear)?.fallbackPhoto?.asset;
 	const photoAsset = member?.photo?.[suf]?.asset ?? fallbackAsset;
 	const photoUrl = photoAsset ? urlFor(photoAsset).url() : "";
@@ -75,7 +75,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 			>
 				<img
 					src={photoUrl}
-					alt={member?.name || t("team.fallbackPhotoAlt")}
+					alt={member?.name || labels.fallbackPhotoAlt}
 					loading="lazy"
 					className="aspect-square object-cover rounded-[50%] shadow-small-glow"
 				/>
@@ -87,7 +87,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.linkedin}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.linkedin")}
+							aria-label={labels.linkedin}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faLinkedin} />
@@ -98,7 +98,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.github}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.github")}
+							aria-label={labels.github}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faGithub} />
@@ -109,7 +109,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.website}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.website")}
+							aria-label={labels.website}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faGlobe} />
@@ -126,6 +126,14 @@ export default function TeamPage({ teams }) {
 	const t_teamNames = t("team.teams");
 	const t_positions = t("team.positions");
 	const memberLabel = t("team.member");
+
+	// Pre-fetch translated labels to prevent calling t() (and creating nanostore subscriptions) per TeamMemberCard
+	const labels = {
+		fallbackPhotoAlt: t("team.fallbackPhotoAlt"),
+		linkedin: t("accessibility.linkedin"),
+		github: t("accessibility.github"),
+		website: t("accessibility.website"),
+	};
 
 	const builder = createImageUrlBuilder(sanityClient);
 	const urlFor = source => builder.image(source);
@@ -271,6 +279,7 @@ export default function TeamPage({ teams }) {
 											teams={teams}
 											getTitle={getTitle}
 											urlFor={urlFor}
+											labels={labels}
 										/>
 									))}
 								</ul>


### PR DESCRIPTION
💡 What: Moved `t()` translation calls out of the `TeamMemberCard` and evaluated them at the top-level of `TeamPage`, passing them down as a single `labels` object instead.
🎯 Why: `t()` uses a `useStore` subscription under the hood. When mapping over the team lists, the former implementation spawned 4 hooks *per member* (for `fallbackPhotoAlt` and ARIA labels), creating massive overhead on rendering and language switching. Furthermore, one of these calls was used inside a short-circuit expression `member?.name || t("...")` which breaks the Rules of Hooks.
📊 Impact: Reduces $4 \times N$ React store subscriptions down to exactly 4 for the entire TeamPage mount, creating a measurable performance boost. Fixes a hook violation.
🔬 Measurement: Verified by observing the single set of translation evaluation and standard test builds.

---
*PR created automatically by Jules for task [18040622377603113694](https://jules.google.com/task/18040622377603113694) started by @arcanistzed*