### PR TITLE
fix(a11y): make blog cards keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Found a common accessibility pitfall: a mobile hamburger menu button was using the same `aria-label` ("Navigation Bar") as its parent `<nav>` element. This creates confusion for screen reader users as they hear the exact same label for both the container and the control that toggles it. Another improvement was adding an aria-label to the language toggler ("EN"/"FR"), which without a label, just reads "E N" out of context.
 **Action:** When implementing mobile menus, always ensure the toggle button has a distinct, action-oriented label (e.g., "Toggle Navigation Menu") separate from the landmark label of the `<nav>` element itself. Always provide context to language togglers.
+
+## 2024-05-23 - Interactive List Items Acting as Cards Need Keyboard Support
+
+**Learning:** Interactive list items (`<li>`) acting as navigational cards (with `onClick` handlers) are completely inaccessible to keyboard and screen reader users by default. Mouse users can click anywhere on the card, but keyboard users are unable to focus or trigger the card.
+**Action:** Always add `tabIndex={0}`, `role="link"` (or `role="button"` if appropriate), `onKeyDown` handlers (for `Enter` and `Space`), and explicit `focus-visible` styles to any non-native interactive element (like `<li>` or `<div>`) that serves as a clickable card. This ensures functional parity between mouse and keyboard users.

--- a/src/components/Blog/BlogPage.jsx
+++ b/src/components/Blog/BlogPage.jsx
@@ -31,8 +31,16 @@ export default function BlogPage({ posts }) {
 						{posts?.map((post, i) => (
 							<li
 								key={i}
-								className="basis-1/2 lg:basis-full p-3 md:mb-4 md:border md:border-primary md:rounded-3xl md:p-0 hover:cursor-pointer transition-all duration-300"
+								className="basis-1/2 lg:basis-full p-3 md:mb-4 md:border md:border-primary md:rounded-3xl md:p-0 hover:cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:rounded-3xl transition-all duration-300"
 								onClick={() => (globalThis.location.href = `/blog/${post.slug.current}`)}
+								onKeyDown={e => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										globalThis.location.href = `/blog/${post.slug.current}`;
+									}
+								}}
+								tabIndex={0}
+								role="link"
 								data-aos="fade-up"
 								data-aos-offset={i >= 2 ? "-100" : "0"}
 							>


### PR DESCRIPTION
💡 **What**: Added `tabIndex={0}`, `role="link"`, `onKeyDown` handlers, and `focus-visible` styles to the interactive `<li>` elements acting as blog post cards in `BlogPage.jsx`.
🎯 **Why**: Interactive list items (`<li>`) acting as navigational cards (with `onClick` handlers) are completely inaccessible to keyboard and screen reader users by default. Mouse users can click anywhere on the card, but keyboard users are unable to focus or trigger the card.
♿ **Accessibility**: Improved keyboard navigation and screen reader semantics by enabling `Enter`/`Space` key interaction and adding proper focus feedback.

I've also logged this insight in the Palette journal for future reference.

---
*PR created automatically by Jules for task [7224065859418665763](https://jules.google.com/task/7224065859418665763) started by @arcanistzed*