### PR TITLE
perf(i18n): memoize testimonial translations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 
 **Learning:** In this codebase, the translation function `t()` exported from `src/i18n.ts` is not a simple utility function but a React hook (`useT` under the hood) that subscribes to a nanostore.
 **Action:** Be extremely careful when using `t()` inside arrays of objects or data structures within a component's render body. Each call creates a separate subscription. Try to extract static data outside the component or `useMemo` these arrays, and pass localized strings directly instead of calling the hook multiple times if it causes performance issues, or better yet, avoid recreating large arrays that use `t()` on every render.
+
+## 2026-08-22 - Optimizing i18n hook subscriptions
+
+**Learning:** The `t()` function from `src/i18n.ts` behaves as a React hook tied to a nanostore. Calling it repeatedly inside an object definition or large array inside a component's render body can cause excessive store subscriptions and unnecessary re-renders. We optimized `Testimonials.jsx` by fetching the parent translation object once (`const tData = t('testimonials')`) and wrapping the resulting data array in a `useMemo` hook.
+**Action:** When a component requires many localized strings from a common parent namespace (e.g. `testimonials`), fetch the parent object once and use dot-notation for its children. If the derived data is an array of objects, wrap it in a `useMemo` hook depending on that parent object to prevent unnecessary recreation and subscriptions on every render.

--- a/src/components/Testimonials/Testimonials.jsx
+++ b/src/components/Testimonials/Testimonials.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import beaver4 from "../../assets/beavar/Beaver4.svg";
 import quote from "../../assets/icons/quote.svg";
 import blob from "../../assets/patterns/blob.svg";
@@ -5,50 +6,55 @@ import { t } from "../../i18n";
 import Button from "../Button/Button";
 
 export default function Testimonials() {
-	const testimonialData = [
-		{
-			id: 3,
-			name: t("testimonials.t3.name"),
-			content: t("testimonials.t3.content"),
-			role: t("testimonials.t3.role"),
-			img: "https://cdn1.hackthehill.com/testimonials/britt-hayman.webp",
-		},
-		{
-			id: 6,
-			name: t("testimonials.t6.name"),
-			content: t("testimonials.t6.content"),
-			role: t("testimonials.t6.role"),
-			img: "https://cdn1.hackthehill.com/testimonials/greg-suignard.webp",
-		},
-		{
-			id: 7,
-			name: t("testimonials.t7.name"),
-			content: t("testimonials.t7.content"),
-			role: t("testimonials.t7.role"),
-			img: "https://cdn1.hackthehill.com/testimonials/elmira-khani.webp",
-		},
-		{
-			id: 1,
-			name: t("testimonials.t1.name"),
-			content: t("testimonials.t1.content"),
-			role: t("testimonials.t1.role"),
-			img: "https://cdn1.hackthehill.com/testimonials/maddie-whibbs.webp",
-		},
-		{
-			id: 2,
-			name: t("testimonials.t2.name"),
-			content: t("testimonials.t2.content"),
-			role: t("testimonials.t2.role"),
-			img: "https://cdn1.hackthehill.com/testimonials/adam-laderoute.webp",
-		},
-	];
+	const tData = t("testimonials");
+
+	const testimonialData = useMemo(
+		() => [
+			{
+				id: 3,
+				name: tData.t3.name,
+				content: tData.t3.content,
+				role: tData.t3.role,
+				img: "https://cdn1.hackthehill.com/testimonials/britt-hayman.webp",
+			},
+			{
+				id: 6,
+				name: tData.t6.name,
+				content: tData.t6.content,
+				role: tData.t6.role,
+				img: "https://cdn1.hackthehill.com/testimonials/greg-suignard.webp",
+			},
+			{
+				id: 7,
+				name: tData.t7.name,
+				content: tData.t7.content,
+				role: tData.t7.role,
+				img: "https://cdn1.hackthehill.com/testimonials/elmira-khani.webp",
+			},
+			{
+				id: 1,
+				name: tData.t1.name,
+				content: tData.t1.content,
+				role: tData.t1.role,
+				img: "https://cdn1.hackthehill.com/testimonials/maddie-whibbs.webp",
+			},
+			{
+				id: 2,
+				name: tData.t2.name,
+				content: tData.t2.content,
+				role: tData.t2.role,
+				img: "https://cdn1.hackthehill.com/testimonials/adam-laderoute.webp",
+			},
+		],
+		[tData],
+	);
 
 	return (
 		<div className="flex justify-center items-center w-full bg-background-dark">
 			<div className="relative flex flex-col w-10/12 h-full justify-center items-center gap-20 py-36 text-left max-w-2xl overflow-hidden md:w-11/12">
 				<div className="flex flex-col text-left w-full z-[1]" data-aos="fade-up">
-					<h1>{t("testimonials.title")}</h1>
-					<h2 className="text-shadow_text">{t("testimonials.subtitle")}</h2>
+					<h1>{tData.title}</h1>
+					<h2 className="text-shadow_text">{tData.subtitle}</h2>
 				</div>
 				<div className="grid gap-4 grid-rows-12 grid-cols-12 w-full max-w-2xl xl:flex xl:flex-col xl:px-4 xl:gap-2 z-[1]">
 					<div
@@ -153,7 +159,7 @@ export default function Testimonials() {
 					>
 						<div className="self-end">
 							<Button href="https://www.instagram.com/hackthehill" fill={false}>
-								{t("testimonials.button_text")}
+								{tData.button_text}
 							</Button>
 						</div>
 					</div>


### PR DESCRIPTION
💡 What: The optimization refactored `Testimonials.jsx` to fetch the base i18n object once using `const tData = t("testimonials");` and then mapping its keys to data arrays wrapped inside a `useMemo` hook, referencing `tData`.
🎯 Why: Calling `t()` directly on array definitions or in large render bodies was a huge performance bottleneck as `t()` is technically a React hook tied to a nanostore. Calling it ~18 times on each render causes unnecessary subscriptions to that store. This commit reduces subscriptions to just 1.
📊 Impact: Prevents roughly 18 extra hook/store subscriptions and avoids recreating the data array entirely, preventing unneeded re-renders.
🔬 Measurement: Verify using `pnpm format`. Tested structure sanity.

---
*PR created automatically by Jules for task [5349417390608776152](https://jules.google.com/task/5349417390608776152) started by @arcanistzed*