### PR TITLE
⚡ Bolt: Hoist t() hook in TeamPage to avoid O(n) store subscriptions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,4 @@
-## 2024-03-21 - i18n hook usage within components
 
-**Learning:** In this codebase, the translation function `t()` exported from `src/i18n.ts` is not a simple utility function but a React hook (`useT` under the hood) that subscribes to a nanostore.
-**Action:** Be extremely careful when using `t()` inside arrays of objects or data structures within a component's render body. Each call creates a separate subscription. Try to extract static data outside the component or `useMemo` these arrays, and pass localized strings directly instead of calling the hook multiple times if it causes performance issues, or better yet, avoid recreating large arrays that use `t()` on every render.
+## 2024-03-21 - i18n hook usage within components
+**Learning:** In this codebase, the translation function `t()` exported from `src/i18n.ts` is not a simple utility function but a React hook (`useT` under the hood) that subscribes to a nanostore. Calling it multiple times inside lists (e.g., mapped components) creates O(n) re-subscriptions and severely impacts performance.
+**Action:** Hoist `t()` calls out of list render bodies and pass localized strings directly to child components via props instead.

--- a/src/components/Team/TeamPage.jsx
+++ b/src/components/Team/TeamPage.jsx
@@ -58,7 +58,7 @@ const sortRank = rank => {
 	return rank;
 };
 
-function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) {
+function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor, labels }) {
 	const fallbackAsset = teams.find(t => t.year.toString() === selectedYear)?.fallbackPhoto?.asset;
 	const photoAsset = member?.photo?.[suf]?.asset ?? fallbackAsset;
 	const photoUrl = photoAsset ? urlFor(photoAsset).url() : "";
@@ -75,7 +75,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 			>
 				<img
 					src={photoUrl}
-					alt={member?.name || t("team.fallbackPhotoAlt")}
+					alt={member?.name || labels.fallbackPhotoAlt}
 					loading="lazy"
 					className="aspect-square object-cover rounded-[50%] shadow-small-glow"
 				/>
@@ -87,7 +87,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.linkedin}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.linkedin")}
+							aria-label={labels.linkedin}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faLinkedin} />
@@ -98,7 +98,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.github}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.github")}
+							aria-label={labels.github}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faGithub} />
@@ -109,7 +109,7 @@ function TeamMemberCard({ member, suf, selectedYear, teams, getTitle, urlFor }) 
 							href={member.website}
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={t("accessibility.website")}
+							aria-label={labels.website}
 							className="transition-all duration-300 text-white hover:opacity-100 focus-visible:opacity-100 opacity-80"
 						>
 							<Icon icon={faGlobe} />
@@ -126,6 +126,14 @@ export default function TeamPage({ teams }) {
 	const t_teamNames = t("team.teams");
 	const t_positions = t("team.positions");
 	const memberLabel = t("team.member");
+	// Optimization: Hoisting `t()` calls to avoid O(n) store subscriptions in the mapped child components.
+	// This reduces redundant store hook calls during rendering from ~4n per team member to just 4 per page render.
+	const labels = {
+		fallbackPhotoAlt: t("team.fallbackPhotoAlt"),
+		linkedin: t("accessibility.linkedin"),
+		github: t("accessibility.github"),
+		website: t("accessibility.website"),
+	};
 
 	const builder = createImageUrlBuilder(sanityClient);
 	const urlFor = source => builder.image(source);
@@ -271,6 +279,7 @@ export default function TeamPage({ teams }) {
 											teams={teams}
 											getTitle={getTitle}
 											urlFor={urlFor}
+											labels={labels}
 										/>
 									))}
 								</ul>


### PR DESCRIPTION
💡 **What:** Hoisted the `t()` function calls in the `TeamPage.jsx` component and passed the translations down to the `TeamMemberCard` components via a `labels` prop.

🎯 **Why:** The `t()` function uses `useStore` to subscribe to a nanostore under the hood. Previously, `t()` was called repeatedly inside the mapped `TeamMemberCard` components, creating O(N) store subscriptions per team member.

📊 **Impact:** Reduces redundant store hook subscriptions during rendering from ~4n per team member to just 4 per page render. This significantly lowers the render overhead for the Team page which loops through a large number of components.

🔬 **Measurement:** Open the Team page on a slower device and profile the React render phase, specifically looking at hook subscription overhead. Render timings should be demonstrably faster.

---
*PR created automatically by Jules for task [9615652563429151763](https://jules.google.com/task/9615652563429151763) started by @arcanistzed*