### PR TITLE
🎨 Palette: Add aria-current to navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Found a common accessibility pitfall: a mobile hamburger menu button was using the same `aria-label` ("Navigation Bar") as its parent `<nav>` element. This creates confusion for screen reader users as they hear the exact same label for both the container and the control that toggles it. Another improvement was adding an aria-label to the language toggler ("EN"/"FR"), which without a label, just reads "E N" out of context.
 **Action:** When implementing mobile menus, always ensure the toggle button has a distinct, action-oriented label (e.g., "Toggle Navigation Menu") separate from the landmark label of the `<nav>` element itself. Always provide context to language togglers.
+
+## 2026-08-24 - Navigation Active State A11y
+
+**Learning:** Relying solely on text color or font weight for active state in navigation isn't sufficient for screen readers. Using `aria-current="page"` communicates the active page semantically.
+**Action:** Always verify that navigation menus include `aria-current` when styling active links.

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -99,6 +99,7 @@ export default function Navigation(props) {
 						{["events", "blog", "team", "documents"].map(link => (
 							<a
 								href={link ? `/${link}` : "#"}
+								aria-current={props.pathName === `/${link}` ? "page" : undefined}
 								className={`flex h-full items-center border-none p-4 cursor-pointer font-bold transition-all duration-100 lg:border lg:rounded-xl hover:text-shade-1 focus-visible:text-shade-1 ${
 									props.pathName === `/${link}` ? "text-shade-1" : "text-shade-3"
 								}`}


### PR DESCRIPTION
💡 **What**: Added `aria-current="page"` to the currently active navigation link inside `src/components/Navigation/Navigation.jsx`.
🎯 **Why**: To provide semantic context for screen readers, as they cannot interpret the visual changes indicating active state.
♿ **Accessibility**: Significant improvement to navigation context for assistive technology users.

---
*PR created automatically by Jules for task [1881832027064715872](https://jules.google.com/task/1881832027064715872) started by @arcanistzed*